### PR TITLE
implement Hijack if underlaying writer supports it

### DIFF
--- a/prom.go
+++ b/prom.go
@@ -43,7 +43,7 @@ func (w *statusWriter) Write(b []byte) (int, error) {
 func (w *statusWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	writer, ok := w.ResponseWriter.(http.Hijacker)
 	if !ok {
-		panic("not supported by the underlying writer")
+		return nil, nil, fmt.Errorf("not supported by the underlying writer")
 	}
 	return writer.Hijack()
 }


### PR DESCRIPTION
We tried to implement gorilla websockets in our system but it failed because the Hijack method was not implemented on the statusWriter.

This change is working on our system.